### PR TITLE
Fix "Warning on console after reorder"

### DIFF
--- a/SQReorderableStackView/Classes/SQReorderableStackView.swift
+++ b/SQReorderableStackView/Classes/SQReorderableStackView.swift
@@ -274,7 +274,7 @@ public class SQReorderableStackView: UIStackView, UIGestureRecognizerDelegate {
                 // Hide the temporaryView, show the actualView
                 self.temporaryView.removeFromSuperview()
                 self.actualView.alpha = 1
-                self.clipsToBounds = !self.clipsToBoundsWhileReordering
+                self.clipsToBounds = false
         })
         
     }


### PR DESCRIPTION
Fixes the issue referenced here: https://github.com/markedwardmurray/SQReorderableStackView/issues/1 by adjusting the logic- if `self.clipsToBoundsWhileReordering` is false, during the cleanup phase, `self.clipsToBounds` will be set to `true` which isn't what we want (as far as I can tell - the default value is `false`, so I'm thinking we'd want to set it back to that).

To avoid other future bugs, it might make sense to store the value of `clipsToBounds` during `prepareForReordering` then set it back to that value in `cleanupUpAfterReordering`. If needed, I can submit a PR to do that, too :)